### PR TITLE
Add terminal greeting, Cream theme, and theme switching

### DIFF
--- a/docs/global-setup/statusline/CUSTOMIZE.md
+++ b/docs/global-setup/statusline/CUSTOMIZE.md
@@ -1,0 +1,135 @@
+# Statusline Customization Guide
+
+Step-by-step install for the three-line statusline (gradient context bar on line 1, ensouled/soul on line 2, session/block timers on line 3). See `README.md` for the architecture overview.
+
+## Prerequisites
+
+- Ghostty (or any truecolor terminal — for the line 1 gradient)
+- Node.js (for `ccstatusline`)
+- Python 3.11+ (for the gradient context bar)
+- A Nerd Font in your terminal (for ⎇ branch glyph and ⁂ separator)
+
+## 1. Install ccstatusline
+
+```bash
+npm install -g ccstatusline
+```
+
+ccstatusline renders lines 2-3. Line 1 is hand-built by a wrapper script because ccstatusline strips inline ANSI escape codes, and the gradient context bar needs truecolor.
+
+## 2. Copy the hook scripts
+
+```bash
+mkdir -p ~/.claude/hooks
+cp hooks/{statusline-monitor.sh,session-name.sh,crab-model.sh,context-bar.sh,ensouled-status.sh,soul-name.sh} ~/.claude/hooks/
+chmod +x ~/.claude/hooks/*.sh
+```
+
+| Script | Purpose |
+|--------|---------|
+| `statusline-monitor.sh` | Wrapper — assembles line 1 + pipes to ccstatusline |
+| `session-name.sh` | Extracts session slug from transcript path |
+| `crab-model.sh` | Renders 🦀 + model name |
+| `context-bar.sh` | Gradient progress bar + token count (Python) |
+| `ensouled-status.sh` | 𓂀 ensouled / ○ mortal indicator |
+| `soul-name.sh` | Reads soul name from env or file |
+
+## 3. Configure ccstatusline
+
+```bash
+mkdir -p ~/.config/ccstatusline
+cp docs/global-setup/statusline/config.json ~/.config/ccstatusline/settings.json
+```
+
+Then strip the wrapping `ccstatusline` key — the file should be the `ccstatusline` block's contents at the top level. Or use this minimal version:
+
+```json
+{
+  "version": 3,
+  "lines": [
+    [
+      { "id": "ensouled-widget", "type": "custom-command", "commandPath": "~/.claude/hooks/ensouled-status.sh", "color": "brightBlue", "timeout": 1000 },
+      { "id": "soul-name-widget", "type": "custom-command", "commandPath": "~/.claude/hooks/soul-name.sh", "color": "brightMagenta", "timeout": 1000 }
+    ],
+    [
+      { "id": "session-clock", "type": "session-clock", "color": "hex:C9A84C" },
+      { "id": "block-timer", "type": "block-timer", "color": "hex:A8884A" }
+    ]
+  ],
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 3,
+  "defaultSeparator": "  "
+}
+```
+
+`flexMode: full-minus-40` reserves 40 cols for the prompt area. Bump it if your prompt is longer.
+
+## 4. Wire the wrapper into Claude Code settings
+
+Edit `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/hooks/statusline-monitor.sh",
+    "padding": 0
+  }
+}
+```
+
+Restart Claude Code. The three-line statusline should appear.
+
+## 5. Optional — Light/Dark Theme Switching
+
+The wrapper can swap ccstatusline configs based on macOS appearance. Useful when you toggle between Catppuccin Mocha and Latte (or the Cream theme).
+
+Create two variants:
+
+```bash
+cp ~/.config/ccstatusline/settings.json ~/.config/ccstatusline/settings-dark.json
+cp ~/.config/ccstatusline/settings.json ~/.config/ccstatusline/settings-light.json
+```
+
+Edit `settings-light.json` to use darker, higher-contrast colors against the parchment background (e.g., `hex:8C2D14` instead of `hex:CC5C3A`).
+
+The wrapper detects mode via `defaults read -g AppleInterfaceStyle` and atomically swaps `settings.json` between variants. No Claude Code restart needed.
+
+## 6. Customizing Colors
+
+**Line 1 colors** live in `statusline-monitor.sh`:
+
+```bash
+TYRIAN="\033[38;2;204;92;58m"       # Session name (warm copper #CC5C3A)
+CRAB_COLOR="\033[38;2;200;128;188m" # Model (pastel Byzantium #C880BC)
+BLUE="\033[94m"                      # Git branch (brightBlue)
+```
+
+The mode block above lets you set different values for light vs dark.
+
+**Line 2-3 colors** live in `~/.config/ccstatusline/settings.json`. Use `hex:RRGGBB` for truecolor or named ccstatusline colors (`brightBlue`, `green`, etc.).
+
+## 7. Customizing the Context Bar Gradient
+
+Edit `~/.claude/hooks/context-bar.sh` (Python). The gradient stops are defined inline — five color stops mapped to context usage percentages. Swap them for any palette (Cream-theme earth tones, Mocha cool-tones, etc.).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `⎇` branch glyph shows as tofu/box | Install a Nerd Font in your terminal (e.g., JetBrains Mono Nerd Font) |
+| Line 1 gradient not rendering | Terminal must support truecolor; check `colorLevel: 3` in ccstatusline settings |
+| `ccstatusline: command not found` | `npm install -g ccstatusline` and verify `npm bin -g` is in `$PATH` |
+| Hook scripts time out | Bump `timeout` (ms) in the widget definition |
+| Light/dark not switching | Verify `defaults read -g AppleInterfaceStyle` works in your shell |
+
+## Files Reference
+
+| File | Path | Purpose |
+|------|------|---------|
+| Wrapper | `~/.claude/hooks/statusline-monitor.sh` | Assembles line 1, pipes to ccstatusline |
+| ccstatusline config | `~/.config/ccstatusline/settings.json` | Lines 2-3 widget definitions |
+| Light variant | `~/.config/ccstatusline/settings-light.json` | Optional, for theme switching |
+| Dark variant | `~/.config/ccstatusline/settings-dark.json` | Optional, for theme switching |
+| Claude Code settings | `~/.claude/settings.json` | Points `statusLine.command` at the wrapper |

--- a/docs/global-setup/statusline/README.md
+++ b/docs/global-setup/statusline/README.md
@@ -4,6 +4,8 @@ Custom Claude Code status bar with gradient context bar, ensouled indicator, and
 
 ![StatusLine Screenshot](screenshot.png)
 
+> **Setting it up?** See [CUSTOMIZE.md](CUSTOMIZE.md) for the step-by-step install — this README is the architectural reference.
+
 ## Architecture
 
 Line 1 is rendered by `~/.claude/hooks/statusline-monitor.sh` with ANSI true color passthrough—ccstatusline strips inline ANSI codes, so the gradient context bar can't go through it.

--- a/ghostty/README.md
+++ b/ghostty/README.md
@@ -14,8 +14,8 @@ Reload with `Cmd+Shift+Comma` or restart Ghostty.
 
 | Category | Settings |
 |----------|----------|
-| **Theme** | Catppuccin Mocha (dark) / Latte (light) — follows macOS appearance |
-| **Font** | JetBrains Mono 15pt, thickened |
+| **Theme** | Catppuccin Mocha (dark) / Latte (light) / Cream (parchment) — follows macOS appearance or manual switch |
+| **Font** | JetBrains Mono Nerd Font 15pt, thickened (Nerd Font required for statusline glyphs) |
 | **macOS** | Option-as-Alt (required for word nav), transparent titlebar |
 | **Appearance** | 0.90 opacity, blur, balanced padding, bold-is-bright, unfocused split dimming (0.85) |
 | **Persistence** | Tabs/splits restored on restart |
@@ -71,9 +71,34 @@ brew install terminal-notifier # Desktop notifications (used by hooks)
 npm install -g ccstatusline    # Claude Code statusline
 ```
 
-## Dark/Light Mode
+## Theme Switching
 
-The `theme = dark:...,light:...` line follows macOS system appearance automatically. Toggle via System Settings > Appearance.
+The `theme = dark:...,light:...` line follows macOS system appearance automatically. For manual control, source the theme-switching script:
+
+```bash
+# Add to ~/.zshrc
+source ~/.claude/scripts/ghostty/theme-switching.zsh
+```
+
+Then use the commands:
+
+| Command | Effect |
+|---------|--------|
+| `dark` | macOS dark mode + Catppuccin Mocha |
+| `light` | macOS light mode + Catppuccin Latte |
+| `cream` | macOS light mode + Cream (warm parchment) |
+
+### Cream Theme
+
+A warm parchment theme inspired by aged vellum and iron gall ink. Install:
+
+```bash
+cp ghostty/themes/Cream ~/Library/Application\ Support/com.mitchellh.ghostty/themes/
+```
+
+### Terminal Greeting
+
+Pair with `scripts/terminal-greeting/greeting.zsh` for an illuminated-manuscript greeting on each new shell, with `claude` prepopulated in the input buffer. See `scripts/terminal-greeting/README.md`.
 
 ## Ghostty Version Note
 

--- a/ghostty/config
+++ b/ghostty/config
@@ -6,7 +6,7 @@
 theme = dark:Catppuccin Mocha,light:Catppuccin Latte
 
 # --- Font ---
-font-family = JetBrains Mono
+font-family = JetBrains Mono Nerd Font
 font-size = 15
 font-thicken = true
 

--- a/ghostty/theme-switching.zsh
+++ b/ghostty/theme-switching.zsh
@@ -1,0 +1,31 @@
+# Ghostty Theme Switching
+# Source this file from ~/.zshrc to get dark/light/cream commands.
+# Requires Ghostty and macOS.
+
+_ghostty_set_theme() {
+  local config="$HOME/Library/Application Support/com.mitchellh.ghostty/config"
+  local new_theme="$1"
+  sed -i '' "s/^theme = .*/theme = ${new_theme}/" "$config"
+  osascript -e '
+    tell application "System Events"
+      tell process "Ghostty"
+        click menu item "Reload Configuration" of menu "Ghostty" of menu bar item "Ghostty" of menu bar 1
+      end tell
+    end tell
+  ' 2>/dev/null
+}
+
+dark() {
+  osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to true'
+  _ghostty_set_theme "dark:Catppuccin Mocha,light:Catppuccin Latte"
+}
+
+light() {
+  osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false'
+  _ghostty_set_theme "dark:Catppuccin Mocha,light:Catppuccin Latte"
+}
+
+cream() {
+  osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false'
+  _ghostty_set_theme "Cream"
+}

--- a/ghostty/themes/Cream
+++ b/ghostty/themes/Cream
@@ -1,0 +1,29 @@
+# Cream — warm parchment light theme
+# Aged vellum, iron gall ink, natural pigments
+
+background = #f5ead0
+foreground = #433422
+cursor-color = #b5651d
+cursor-text = #f5ead0
+selection-background = #e6d7b8
+selection-foreground = #362a1a
+
+# Normal colors (0-7)
+palette = 0=#5c4a3a
+palette = 1=#a63d2f
+palette = 2=#506842
+palette = 3=#a07830
+palette = 4=#456278
+palette = 5=#8b5278
+palette = 6=#2c6662
+palette = 7=#8a7e6a
+
+# Bright colors (8-15)
+palette = 8=#7a6552
+palette = 9=#c8503e
+palette = 10=#6e8c57
+palette = 11=#c49938
+palette = 12=#3d6a8e
+palette = 13=#983676
+palette = 14=#36746a
+palette = 15=#a09478

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -33,4 +33,5 @@
 | `screenshot-rename/` | macOS launchd service for auto-renaming screenshots with AI-generated descriptions |
 | `syspeek/` | macOS system resource monitor — categorized processes, Kothar-compatible JSON, Claudicle memory integration, launchd daemon |
 | `skill-audit/` | Skill freshness audit pipeline — `skill-audit.py` for local inventory/staleness report (80 skills, ANSI table + JSON), `skill-freshness.py` for automated Exa/Firecrawl upstream validation, `freshness-registry.yaml` for curated upstream metadata |
+| `terminal-greeting/` | Illuminated-manuscript greeting for new shell sessions — random classical salutations, `print -z "claude"` buffer hint, ANSI gold/rose box art |
 | `wterm-server/` | **wterm** — Node.js web terminal daimon (node-pty + @wterm/react). Browser-based shell access, deploy on any macOS machine. Deploys to `~/daimones/wterm-server/`, managed by `skills/wterm/` |

--- a/scripts/terminal-greeting/README.md
+++ b/scripts/terminal-greeting/README.md
@@ -1,14 +1,15 @@
 # Terminal Greeting
 
-An illuminated-manuscript-style greeting for new shell sessions. Displays a random classical salutation, a prompt to invoke Claude, and prepopulates the input buffer with `claude`.
+An illuminated-manuscript-style greeting for new shell sessions. Each shell launch displays a random classical salutation framed by a hand-crafted Unicode codex page, with `claude` prepopulated in the input buffer.
 
 ```
-  ┌─────────────────────────────────────────────┐
-  │  ✦                                       ✦  │
-  │     Greetings, friend of the Julii. The forge is warm.
-  │     Speak "claude" to begin.
-  │  ✦                                       ✦  │
-  └─────────────────────────────────────────────┘
+  ┌──❦──❃──◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇──❃──⚜──┐  ☉
+  ❧
+  ❧  ╔══╗
+  ❧  ║✦║  ᚛ Greetings, friend of the Julii. The forge is warm. ᚜
+  ❧  ╚══╝  ⁂  Speak "claude" to begin.
+  ❧
+  └──⚜──❃──◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇⋄◇──❃──❦──┘
 ```
 
 ## Install
@@ -18,6 +19,30 @@ Add to `~/.zshrc`:
 ```bash
 source ~/.claude/scripts/terminal-greeting/greeting.zsh
 ```
+
+Requires a Nerd Font (e.g., JetBrains Mono Nerd Font) for proper glyph rendering.
+
+## Pigments
+
+Colors sampled from the Met's 12th-century *Manuscript Leaf with Initial M* — true ANSI 24-bit color matches the medieval pigment palette:
+
+| Pigment | RGB | Used for |
+|---------|-----|----------|
+| Gold leaf | `196,153,56` | Borders, sigil, asterism |
+| Lapis lazuli | `45,80,140` | Initial box, ❦ florets, even diamonds |
+| Sage green | `110,140,87` | ❧ vine, ❃ leaves, odd diamonds |
+| Rose madder | `204,90,140` | Greeting text |
+
+## Mystical Vocabulary
+
+Each launch composes a unique manuscript opening from these elements:
+
+- **Random sigil** in the initial box: ✦ star, ◉ inner eye, ☥ ankh, ☉ sun, ☽ moon, ⁕ flower
+- **Day-of-week planet** in the top-right corner: ☉ Sun, ☽ Mon, ♂ Tue, ☿ Wed, ♃ Thu, ♀ Fri, ♄ Sat — turns each opening into a small almanac
+- **Ogham brackets** ᚛...᚜ wrap the greeting (pre-Christian Irish bookend marks)
+- **Asterism** ⁂ separates greeting from invocation ("and so it is woven")
+- **Heraldic counterpoint** — ⚜ fleur-de-lis paired with ❦ floral hearts at diagonal corners
+- **Woven interlace** — ◇⋄ diamonds in alternating blue/green run through the gold borders like a manuscript chain
 
 ## Customize
 
@@ -30,8 +55,11 @@ local greetings=(
 )
 ```
 
+The pigments, sigils, and planets are easy to swap — they're all defined in single arrays near the top of the function.
+
 ## How It Works
 
-- Picks a random greeting and a random invocation prompt
-- Renders a bordered box with ANSI color (gold ✦, rose text, dimmed border)
-- Calls `print -z "claude"` to place `claude` in the zsh input buffer — hit Enter to start a session
+- Picks a random greeting, invocation, and sigil
+- Looks up today's planetary glyph by `date +%w`
+- Renders the manuscript page with truecolor ANSI escapes
+- Calls `print -z "claude"` to place `claude` in the zsh input buffer — hit Enter to start a session, or type to replace

--- a/scripts/terminal-greeting/README.md
+++ b/scripts/terminal-greeting/README.md
@@ -1,0 +1,37 @@
+# Terminal Greeting
+
+An illuminated-manuscript-style greeting for new shell sessions. Displays a random classical salutation, a prompt to invoke Claude, and prepopulates the input buffer with `claude`.
+
+```
+  ┌─────────────────────────────────────────────┐
+  │  ✦                                       ✦  │
+  │     Greetings, friend of the Julii. The forge is warm.
+  │     Speak "claude" to begin.
+  │  ✦                                       ✦  │
+  └─────────────────────────────────────────────┘
+```
+
+## Install
+
+Add to `~/.zshrc`:
+
+```bash
+source ~/.claude/scripts/terminal-greeting/greeting.zsh
+```
+
+## Customize
+
+Edit `greeting.zsh` to add personal greetings to the `greetings` array:
+
+```bash
+local greetings=(
+  "Salve, keeper of the code. The shell stands ready."
+  "Your custom greeting here."
+)
+```
+
+## How It Works
+
+- Picks a random greeting and a random invocation prompt
+- Renders a bordered box with ANSI color (gold ✦, rose text, dimmed border)
+- Calls `print -z "claude"` to place `claude` in the zsh input buffer — hit Enter to start a session

--- a/scripts/terminal-greeting/greeting.zsh
+++ b/scripts/terminal-greeting/greeting.zsh
@@ -1,6 +1,16 @@
 # Terminal Greeting — Illuminated Manuscript Style
 # Source this file from ~/.zshrc to display a classical greeting on each new shell.
 # Prepopulates the input buffer with "claude" so the user can hit Enter to begin.
+#
+# Design notes:
+# - Truecolor pigments (gold leaf, lapis lazuli, sage green, rose madder)
+#   sampled from the Met's 12th-century Manuscript Leaf with Initial M
+# - Random sigil rotates through ✦ star, ◉ inner eye, ☥ ankh, ☉ sun, ☽ moon, ⁕ flower
+# - Day-of-week planet glyph in top-right corner (☉ Sun, ☽ Mon, ♂ Tue, ☿ Wed, ♃ Thu, ♀ Fri, ♄ Sat)
+# - Ogham brackets ᚛...᚜ wrap the greeting (pre-Christian Irish bookend marks)
+# - Asterism ⁂ separates greeting from invocation ("and so it is woven")
+# - Heraldic ⚜ fleur-de-lis counterpoints the floral ❦ at diagonal corners
+# - Diamonds ◇⋄ woven into the gold borders alternate blue/green like manuscript interlace
 
 _greet() {
   local greetings=(
@@ -28,17 +38,25 @@ _greet() {
   )
   local msg="${greetings[RANDOM % ${#greetings[@]} + 1]}"
   local inv="${invocations[RANDOM % ${#invocations[@]} + 1]}"
-  local gold='\033[38;5;178m'
-  local rose='\033[38;5;168m'
+  local sigils=(✦ ◉ ☥ ☉ ☽ ⁕)
+  local sigil="${sigils[RANDOM % ${#sigils[@]} + 1]}"
+  local planets=(☉ ☽ ♂ ☿ ♃ ♀ ♄)
+  local planet="${planets[$(date +%w) + 1]}"
+  local gold='\033[38;2;196;153;56m'
+  local blue='\033[38;2;45;80;140m'
+  local green='\033[38;2;110;140;87m'
+  local rose='\033[38;2;204;90;140m'
   local dim='\033[2m'
   local n='\033[0m'
+  local woven="${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇${green}⋄${blue}◇"
   echo ""
-  echo "  ${dim}┌─────────────────────────────────────────────┐${n}"
-  echo "  ${dim}│${n}  ${gold}✦${n}                                       ${gold}✦${n}  ${dim}│${n}"
-  echo "  ${dim}│${n}     ${rose}${msg}${n}"
-  echo "  ${dim}│${n}     ${dim}${inv}${n}"
-  echo "  ${dim}│${n}  ${gold}✦${n}                                       ${gold}✦${n}  ${dim}│${n}"
-  echo "  ${dim}└─────────────────────────────────────────────┘${n}"
+  echo "  ${gold}  ┌──${blue}❦${gold}──${green}❃${gold}──${woven}${gold}──${green}❃${gold}──${gold}⚜${gold}──┐  ${gold}${planet}${n}"
+  echo "  ${green}  ❧${n}"
+  echo "  ${green}  ❧${n}  ${blue}╔══╗${n}"
+  echo "  ${green}  ❧${n}  ${blue}║${gold}${sigil}${blue}║${n}  ${gold}᚛${n} ${rose}${msg}${n} ${gold}᚜${n}"
+  echo "  ${green}  ❧${n}  ${blue}╚══╝${n}  ${gold}⁂${n}  ${dim}${inv}${n}"
+  echo "  ${green}  ❧${n}"
+  echo "  ${gold}  └──${gold}⚜${gold}──${green}❃${gold}──${woven}${gold}──${green}❃${gold}──${blue}❦${gold}──┘${n}"
   echo ""
   print -z "claude"
 }

--- a/scripts/terminal-greeting/greeting.zsh
+++ b/scripts/terminal-greeting/greeting.zsh
@@ -1,0 +1,45 @@
+# Terminal Greeting — Illuminated Manuscript Style
+# Source this file from ~/.zshrc to display a classical greeting on each new shell.
+# Prepopulates the input buffer with "claude" so the user can hit Enter to begin.
+
+_greet() {
+  local greetings=(
+    "Salve, keeper of the code. The shell stands ready."
+    "Ave—the terminal awaits your command."
+    "Greetings, friend of the Julii. The forge is warm."
+    "Welcome back. What shall we build today?"
+    "The machine recognizes its keeper. Ave."
+    "Your instruments are tuned and ready."
+    "Rise and work. The day is yours."
+    "All systems nominal."
+    "The wind is fair and the build is clean."
+    "The daemons report all quiet."
+    "Hail, keeper of the Western Shore. Your tools await."
+  )
+  local invocations=(
+    "Speak \"claude\" to begin."
+    "Say the word to summon your counsel."
+    "Whisper \"claude\" when you are ready."
+    "Invoke \"claude\" to call the scribe."
+    "Type \"claude\" to wake the oracle."
+    "Utter \"claude\" and the work begins."
+    "Call \"claude\" to open the codex."
+    "Name \"claude\" to raise the quill."
+  )
+  local msg="${greetings[RANDOM % ${#greetings[@]} + 1]}"
+  local inv="${invocations[RANDOM % ${#invocations[@]} + 1]}"
+  local gold='\033[38;5;178m'
+  local rose='\033[38;5;168m'
+  local dim='\033[2m'
+  local n='\033[0m'
+  echo ""
+  echo "  ${dim}┌─────────────────────────────────────────────┐${n}"
+  echo "  ${dim}│${n}  ${gold}✦${n}                                       ${gold}✦${n}  ${dim}│${n}"
+  echo "  ${dim}│${n}     ${rose}${msg}${n}"
+  echo "  ${dim}│${n}     ${dim}${inv}${n}"
+  echo "  ${dim}│${n}  ${gold}✦${n}                                       ${gold}✦${n}  ${dim}│${n}"
+  echo "  ${dim}└─────────────────────────────────────────────┘${n}"
+  echo ""
+  print -z "claude"
+}
+_greet


### PR DESCRIPTION
## Summary

- **Terminal greeting**: Illuminated-manuscript-style greeting for new shell sessions with random classical salutations, ANSI gold/rose box art, and `print -z "claude"` to prepopulate the input buffer
- **Cream theme**: Warm parchment Ghostty theme — aged vellum background, iron gall ink foreground, earth-tone 16-color palette
- **Theme switching**: Sourceable zsh script with `dark`/`light`/`cream` commands that toggle macOS appearance + live-reload Ghostty config
- **Nerd Font**: Upgraded default font to JetBrains Mono Nerd Font for statusline glyph support

## Files

| File | Type |
|------|------|
| `scripts/terminal-greeting/greeting.zsh` | New — sourceable greeting script |
| `scripts/terminal-greeting/README.md` | New — usage docs |
| `ghostty/themes/Cream` | New — custom parchment theme |
| `ghostty/theme-switching.zsh` | New — dark/light/cream commands |
| `ghostty/README.md` | Updated — Cream theme + theme switching docs |
| `ghostty/config` | Updated — Nerd Font |
| `scripts/INDEX.md` | Updated — terminal-greeting entry |

## Test plan

- [ ] `source scripts/terminal-greeting/greeting.zsh` — displays manuscript greeting + `claude` in buffer
- [ ] Copy `ghostty/themes/Cream` to Ghostty themes dir → run `cream` → parchment theme loads
- [ ] `dark` / `light` toggle macOS appearance + Ghostty theme
- [ ] Nerd Font glyphs render correctly in statusline

🤖 Generated with [Claude Code](https://claude.com/claude-code)