### PR TITLE
feat(skills): add Atlas provider to nano-banana-pro

### DIFF
--- a/skills/design-media/nano-banana-pro/README.md
+++ b/skills/design-media/nano-banana-pro/README.md
@@ -1,6 +1,6 @@
 # Nano Banana Pro
 
-The image generation skill. Generate and edit professional-quality images using Google's Gemini 3 Pro Image model---text-to-image, image editing, multi-turn refinement, batch workflows, and a cinematic style guide for documentary-quality output.
+The image generation skill. Generate and edit professional-quality images using Google's Gemini 3 Pro Image model---text-to-image, image editing, multi-turn refinement, batch workflows, and a cinematic style guide for documentary-quality output. Text-to-image generation also supports Atlas Cloud as an explicit opt-in provider while Gemini remains the default.
 
 **Last updated:** 2026-02-27
 
@@ -37,7 +37,8 @@ nano-banana-pro/
     compose_images.py                      # Compose from multiple reference images
     generate_with_references.py            # Style-consistent generation with references
     multi_turn_chat.py                     # Iterative refinement via conversation
-    gemini_images.py                       # Shared API client library
+    gemini_images.py                       # Shared Gemini API client library
+    atlas_images.py                        # Optional Atlas Cloud text-to-image client
     test_connection.py                     # Verify API key and connectivity
 ```
 
@@ -86,11 +87,12 @@ Effective prompts follow a structure: **subject + setting + lighting + style + m
 
 ## Scripts
 
-All scripts use `GEMINI_API_KEY` from environment.
+Gemini scripts use `GEMINI_API_KEY`. The optional Atlas path uses `ATLASCLOUD_API_KEY`.
 
 | Script | Usage |
 |--------|-------|
 | `generate_image.py` | `python3 generate_image.py "A bronze-age craftsman at a forge"` |
+| `generate_image.py` (Atlas) | `python3 generate_image.py "A bronze-age craftsman at a forge" --provider atlas` |
 | `edit_image.py` | `python3 edit_image.py input.png "Add dramatic rim lighting"` |
 | `generate_with_references.py` | `python3 generate_with_references.py "Same style" --ref style.png` |
 | `compose_images.py` | `python3 compose_images.py --images a.png b.png --prompt "Merge"` |

--- a/skills/design-media/nano-banana-pro/SKILL.md
+++ b/skills/design-media/nano-banana-pro/SKILL.md
@@ -5,7 +5,7 @@ description: Generate and edit high-quality images using Google's Nano Banana Pr
 
 # Nano Banana Pro (Gemini 3 Pro Image)
 
-Generate and edit professional-quality images using Google's state-of-the-art Gemini 3 Pro Image model.
+Generate and edit professional-quality images using Google's state-of-the-art Gemini 3 Pro Image model. Gemini remains the default; Atlas Cloud is available as an optional provider for text-to-image generation.
 
 ## API Configuration
 
@@ -16,6 +16,15 @@ export GEMINI_API_KEY="your-api-key-here"
 ```
 
 Get your API key at: https://aistudio.google.com/apikey
+
+For optional Atlas Cloud text-to-image generation, set:
+
+```bash
+export ATLASCLOUD_API_KEY="your-api-key-here"
+python scripts/generate_image.py "A cinematic harbor at sunrise" --provider atlas
+```
+
+The Atlas path validates the configured model against the live catalog, submits one non-retried generation request, polls the prediction with bounded GET retries, and downloads the completed image. Override its live catalog model with `--atlas-model` when needed; Gemini behavior is unchanged when `--provider` is omitted.
 
 ## Quick Start
 

--- a/skills/design-media/nano-banana-pro/scripts/README.md
+++ b/skills/design-media/nano-banana-pro/scripts/README.md
@@ -1,12 +1,13 @@
 # Nano Banana Pro Scripts
 
-Professional-quality image generation and editing using Google's Gemini 3 Pro Image model (Nano Banana Pro). All scripts use the REST API directly for maximum control and compatibility.
+Professional-quality image generation and editing using Google's Gemini 3 Pro Image model (Nano Banana Pro). Gemini remains the default; `generate_image.py --provider atlas` enables optional Atlas Cloud text-to-image generation. All scripts use REST APIs directly for maximum control and compatibility.
 
 ## 📚 Script Overview
 
 | Script | Type | Purpose | Input | Output |
 |--------|------|---------|-------|--------|
 | `gemini_images.py` | Library | Shared functionality for all scripts | N/A | N/A |
+| `atlas_images.py` | Library | Optional Atlas Cloud text-to-image generation | Prompt | Image |
 | `generate_image.py` | CLI | Text-to-image generation | Text prompt | Image(s) |
 | `edit_image.py` | CLI | Image editing with instructions | Image + instruction | Edited image(s) |
 | `compose_images.py` | CLI | Multi-image composition | 2-14 images + instruction | Composed image |
@@ -115,6 +116,9 @@ client.save_response("sunset_edited.png", response)
 ```bash
 # Quick generation
 python generate_image.py "A red sports car"
+
+# Optional Atlas Cloud provider (requires ATLASCLOUD_API_KEY)
+python generate_image.py "A red sports car" --provider atlas --resolution 2k
 
 # Professional headshot
 python generate_image.py "Professional headshot, 85mm lens, soft lighting" \

--- a/skills/design-media/nano-banana-pro/scripts/atlas_images.py
+++ b/skills/design-media/nano-banana-pro/scripts/atlas_images.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Atlas Cloud text-to-image client with guarded async polling."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import requests
+
+
+ATLAS_API_BASE = "https://api.atlascloud.ai"
+DEFAULT_ATLAS_MODEL = "google/nano-banana-pro/text-to-image-developer"
+
+
+def _iter_objects(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from _iter_objects(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_objects(item)
+
+
+def _data_object(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    return data if isinstance(data, dict) else payload
+
+
+class AtlasImageClient:
+    """Generate one image through Atlas Cloud without retrying the billable POST."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = DEFAULT_ATLAS_MODEL,
+        request: Callable[..., requests.Response] = requests.request,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        self.api_key = api_key or os.environ.get("ATLASCLOUD_API_KEY", "")
+        if not self.api_key:
+            raise EnvironmentError(
+                "Atlas Cloud API key required. Set ATLASCLOUD_API_KEY or pass --atlas-api-key"
+            )
+        self.model = model
+        self._request = request
+        self._sleep = sleep
+
+    @property
+    def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "User-Agent": "claude-code-minoan-nano-banana-pro/1.0",
+        }
+
+    def _json_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        authenticated: bool = True,
+        json: dict[str, Any] | None = None,
+        timeout: int = 120,
+    ) -> dict[str, Any]:
+        headers = self._auth_headers if authenticated else {"Accept": "application/json"}
+        response = self._request(
+            method,
+            f"{ATLAS_API_BASE}{path}",
+            headers=headers,
+            json=json,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("Atlas Cloud returned a non-object response")
+        return payload
+
+    def validate_model(self) -> None:
+        """Confirm the configured model is present and enabled in the live catalog."""
+        catalog = self._json_request("GET", "/api/v1/models", authenticated=False)
+        model = next(
+            (
+                item
+                for item in _iter_objects(catalog)
+                if (item.get("model") or item.get("id")) == self.model
+            ),
+            None,
+        )
+        if model is None:
+            raise RuntimeError(f"Atlas Cloud model not found: {self.model}")
+        if model.get("display_console") is not True:
+            raise RuntimeError(f"Atlas Cloud model is not enabled: {self.model}")
+
+    def _poll_prediction(self, prediction_id: str, timeout: int = 240) -> str:
+        deadline = time.monotonic() + timeout
+        transient_errors = 0
+
+        while time.monotonic() < deadline:
+            try:
+                result = self._json_request(
+                    "GET", f"/api/v1/model/prediction/{prediction_id}"
+                )
+                transient_errors = 0
+            except (requests.ConnectionError, requests.Timeout):
+                transient_errors += 1
+                if transient_errors > 3:
+                    raise
+                self._sleep(2 ** (transient_errors - 1))
+                continue
+            except requests.HTTPError as exc:
+                status = exc.response.status_code if exc.response is not None else 0
+                if status < 500:
+                    raise
+                transient_errors += 1
+                if transient_errors > 3:
+                    raise
+                self._sleep(2 ** (transient_errors - 1))
+                continue
+
+            data = _data_object(result)
+            status = str(data.get("status", "")).lower()
+            if status in {"completed", "succeeded"}:
+                outputs = data.get("outputs") or []
+                if not outputs or not isinstance(outputs[0], str):
+                    raise RuntimeError("Atlas Cloud completed without an output URL")
+                return outputs[0]
+            if status in {"failed", "timeout", "canceled", "cancelled"}:
+                raise RuntimeError(data.get("error") or f"Atlas generation ended with {status}")
+            self._sleep(3)
+
+        raise TimeoutError(f"Atlas prediction {prediction_id} did not finish in time")
+
+    def _download(self, url: str, output_base: Path) -> Path:
+        if not url.startswith(("https://", "http://")):
+            raise RuntimeError("Atlas Cloud returned an unsupported output URL")
+        response = self._request("GET", url, timeout=120)
+        response.raise_for_status()
+        content_type = response.headers.get("Content-Type", "").split(";", 1)[0]
+        extension = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
+        }.get(content_type, ".png")
+        output_path = output_base.with_suffix(extension)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(response.content)
+        return output_path
+
+    def generate_to_file(
+        self,
+        prompt: str,
+        output_base: Path,
+        *,
+        aspect_ratio: str = "16:9",
+        resolution: str = "1k",
+        temperature: float = 1.0,
+        timeout: int = 240,
+    ) -> Path:
+        self.validate_model()
+        # This billable generation POST is intentionally attempted exactly once.
+        result = self._json_request(
+            "POST",
+            "/api/v1/model/generateImage",
+            json={
+                "model": self.model,
+                "prompt": prompt,
+                "aspect_ratio": aspect_ratio,
+                "resolution": resolution,
+                "temperature": temperature,
+            },
+        )
+        prediction_id = str(_data_object(result).get("id") or "")
+        if not prediction_id:
+            raise RuntimeError(result.get("message") or "Atlas Cloud returned no prediction ID")
+        output_url = self._poll_prediction(prediction_id, timeout=timeout)
+        return self._download(output_url, output_base)

--- a/skills/design-media/nano-banana-pro/scripts/generate_image.py
+++ b/skills/design-media/nano-banana-pro/scripts/generate_image.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """
-Generate images using Google's Nano Banana Pro (Gemini 3 Pro Image) API.
+Generate images using Gemini by default, with Atlas Cloud as an optional provider.
 
 Usage:
     python generate_image.py "prompt text" --api-key YOUR_KEY [options]
 
 Environment variables:
-    GEMINI_API_KEY - API key (can override --api-key flag)
+    GEMINI_API_KEY - Gemini API key (can override --api-key)
+    ATLASCLOUD_API_KEY - Atlas Cloud API key (used with --provider atlas)
+    IMAGE_PROVIDER - Optional default provider: gemini or atlas
 """
 
 import argparse
@@ -22,6 +24,8 @@ try:
 except ImportError:
     print("Error: requests library not installed. Run: pip install requests", file=sys.stderr)
     sys.exit(1)
+
+from atlas_images import AtlasImageClient, DEFAULT_ATLAS_MODEL
 
 
 class NanoBananaProClient:
@@ -242,7 +246,16 @@ Examples:
     )
 
     parser.add_argument("prompt", help="Text prompt describing the image to generate")
+    parser.add_argument("--provider", choices=["gemini", "atlas"],
+                       default=os.environ.get("IMAGE_PROVIDER", "gemini"),
+                       help="Image provider (default: gemini)")
     parser.add_argument("--api-key", help="Gemini API key (or set GEMINI_API_KEY env var)")
+    parser.add_argument("--atlas-api-key",
+                       help="Atlas Cloud API key (or set ATLASCLOUD_API_KEY env var)")
+    parser.add_argument("--atlas-model", default=DEFAULT_ATLAS_MODEL,
+                       help=f"Atlas Cloud model (default: {DEFAULT_ATLAS_MODEL})")
+    parser.add_argument("--resolution", choices=["1k", "2k", "4k"], default="1k",
+                       help="Atlas output resolution (default: 1k; ignored by Gemini)")
     parser.add_argument("--model", default=NanoBananaProClient.DEFAULT_MODEL,
                        help=f"Model to use (default: {NanoBananaProClient.DEFAULT_MODEL})")
     parser.add_argument("--aspect-ratio", default="16:9",
@@ -261,23 +274,35 @@ Examples:
 
     args = parser.parse_args()
 
-    # Get API key
-    api_key = args.api_key or os.environ.get("GEMINI_API_KEY")
-    if not api_key:
-        print("Error: API key required. Use --api-key or set GEMINI_API_KEY environment variable",
-              file=sys.stderr)
-        sys.exit(1)
-
-    # Initialize client
-    client = NanoBananaProClient(api_key, args.model)
-
     print(f"🎨 Generating image with Nano Banana Pro...")
-    print(f"   Model: {args.model}")
+    print(f"   Provider: {args.provider}")
+    print(f"   Model: {args.atlas_model if args.provider == 'atlas' else args.model}")
     print(f"   Prompt: {args.prompt}")
     print(f"   Aspect Ratio: {args.aspect_ratio}")
     print()
 
     try:
+        if args.provider == "atlas":
+            client = AtlasImageClient(args.atlas_api_key, args.atlas_model)
+            output_path = client.generate_to_file(
+                args.prompt,
+                Path(args.output) / f"{args.filename}_image_0_0",
+                aspect_ratio=args.aspect_ratio,
+                resolution=args.resolution,
+                temperature=args.temperature,
+            )
+            print()
+            print("✅ Success! Generated 1 file")
+            print(f"   Output: {output_path.absolute()}")
+            return
+
+        api_key = args.api_key or os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            raise EnvironmentError(
+                "Gemini API key required. Use --api-key or set GEMINI_API_KEY"
+            )
+        client = NanoBananaProClient(api_key, args.model)
+
         # Generate image
         response = client.generate_image(
             prompt=args.prompt,

--- a/skills/design-media/nano-banana-pro/tests/test_atlas_images.py
+++ b/skills/design-media/nano-banana-pro/tests/test_atlas_images.py
@@ -1,0 +1,93 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import requests
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+
+from scripts.atlas_images import AtlasImageClient, DEFAULT_ATLAS_MODEL
+
+
+class FakeResponse:
+    def __init__(self, payload=None, content=b"", content_type="application/json", status=200):
+        self._payload = payload
+        self.content = content
+        self.headers = {"Content-Type": content_type}
+        self.status_code = status
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            error = requests.HTTPError(f"HTTP {self.status_code}")
+            error.response = self
+            raise error
+
+
+class AtlasImageClientTests(unittest.TestCase):
+    def test_generation_posts_once_and_saves_completed_output(self):
+        calls = []
+
+        def request(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            if url.endswith("/api/v1/models"):
+                return FakeResponse({"data": [{"model": DEFAULT_ATLAS_MODEL, "display_console": True}]})
+            if url.endswith("/api/v1/model/generateImage"):
+                return FakeResponse({"data": {"id": "prediction-1"}})
+            if url.endswith("/api/v1/model/prediction/prediction-1"):
+                return FakeResponse({"data": {"status": "completed", "outputs": ["https://cdn.example/image"]}})
+            return FakeResponse(content=b"png-bytes", content_type="image/png")
+
+        client = AtlasImageClient(api_key="test-key", request=request, sleep=lambda _: None)
+        with tempfile.TemporaryDirectory() as tmp:
+            output = client.generate_to_file(
+                "bronze age harbor at sunrise",
+                Path(tmp) / "generated",
+                aspect_ratio="16:9",
+                resolution="2k",
+                temperature=0.8,
+            )
+            self.assertEqual(output.suffix, ".png")
+            self.assertEqual(output.read_bytes(), b"png-bytes")
+
+        post_calls = [call for call in calls if call[0] == "POST"]
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(
+            post_calls[0][2]["json"],
+            {
+                "model": DEFAULT_ATLAS_MODEL,
+                "prompt": "bronze age harbor at sunrise",
+                "aspect_ratio": "16:9",
+                "resolution": "2k",
+                "temperature": 0.8,
+            },
+        )
+
+    def test_prediction_get_has_bounded_transient_retries(self):
+        attempts = 0
+
+        def request(method, url, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise requests.ConnectionError("offline")
+
+        client = AtlasImageClient(api_key="test-key", request=request, sleep=lambda _: None)
+        with self.assertRaises(requests.ConnectionError):
+            client._poll_prediction("prediction-2")
+        self.assertEqual(attempts, 4)
+
+    def test_hidden_model_is_rejected_before_generation(self):
+        def request(method, url, **kwargs):
+            return FakeResponse({"data": [{"model": DEFAULT_ATLAS_MODEL, "display_console": False}]})
+
+        client = AtlasImageClient(api_key="test-key", request=request)
+        with self.assertRaisesRegex(RuntimeError, "not enabled"):
+            client.validate_model()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
- add Atlas Cloud as an explicit optional text-to-image provider
- validate the configured model against the live catalog before generation
- submit the billable generation request once, then use bounded prediction GET retries
- keep Gemini as the unchanged default provider

## Testing
- `python3 -m unittest discover -s skills/design-media/nano-banana-pro/tests -v`
- `python3 -m py_compile` for the provider, CLI, and tests
- CLI `--help` smoke and `git diff --check`
- real Atlas Cloud generation smoke with visual inspection

## Checklist
- [x] Tested locally
- [x] Documentation updated
- [x] No secrets committed
- [x] Examples provided